### PR TITLE
fix: compositeEscape entries are no longer necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -684,8 +684,6 @@
       { "key": "alt+c", "command": "workbench.action.terminal.copySelection", "when": "terminalFocus" },
       { "key": "alt+v", "command": "workbench.action.terminal.paste", "when": "terminalFocus" },
 
-      { "key": "j", "command": "vscode-neovim.compositeEscape1", "when": "neovim.mode == insert && editorTextFocus", "args": "j" },
-      { "key": "k", "command": "vscode-neovim.compositeEscape2", "when": "neovim.mode == insert && editorTextFocus", "args": "k" },
       { "key": "alt+h", "command": "vscode-neovim.send", "args": "<esc><cmd>noh<cr>", "when": "inputFocus && neovim.mode == 'insert' || neovim.mode == 'visual'" },
 
       { "key": "alt+j", "command": "workbench.action.quickOpenSelectNext", "when": "inQuickOpen" },


### PR DESCRIPTION
reference https://github.com/vscode-neovim/vscode-neovim/pull/292

Compositeescape entries are no longer necessary see #292 in VSCode Neovim Github

In addition, these are now deprecated and no longer work in the latest VSCode + Neovim.